### PR TITLE
Add automatic docker build and publish to Github Container Registry

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,7 +36,7 @@ jobs:
           context: .
           # Note: tags has to be all lower-case
           tags: |
-            ghcr.io/frauhottelmann/ard-audiothek-rss:latest
+            ghcr.io/matztam/ard-audiothek-rss:latest
           # build on feature branches, push only on main branch
           push: ${{ github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,44 @@
+name: Build and Publish
+
+on:
+  # run it on push to the default repository branch
+  push:
+    branches: [main]
+
+jobs:
+  # define job to build and publish docker image
+  build-and-push-docker-image:
+    name: Build Docker image and push to repositories
+    # run only when code is compiling and tests are passing
+    runs-on: ubuntu-latest
+
+    # steps to perform in job
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # setup Docker buld action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Github Packages
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.TOKEN }}
+      
+      - name: Build image and push to Docker Hub and GitHub Container Registry
+        uses: docker/build-push-action@v5
+        with:
+          # relative path to the place where source code with Dockerfile is located
+          context: .
+          # Note: tags has to be all lower-case
+          tags: |
+            ghcr.io/frauhottelmann/ARD-Audiothek-RSS:latest
+          # build on feature branches, push only on main branch
+          push: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,7 +36,7 @@ jobs:
           context: .
           # Note: tags has to be all lower-case
           tags: |
-            ghcr.io/frauhottelmann/ARD-Audiothek-RSS:latest
+            ghcr.io/frauhottelmann/ard-audiothek-rss:latest
           # build on feature branches, push only on main branch
           push: ${{ github.ref == 'refs/heads/main' }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM php:8.3-apache
-LABEL org.opencontainers.image.source=https://github.com/frauhottelmann/ARD-Audiothek-RSS/
+LABEL org.opencontainers.image.source=https://github.com/matztam/ARD-Audiothek-RSS
 COPY ./ardaudiothek-rss.php /var/www/html/index.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM php:8.3-apache
-LABEL org.opencontainers.image.source="https://github.com/frauhottelmann/ARD-Audiothek-RSS"
+LABEL org.opencontainers.image.source=https://github.com/frauhottelmann/ARD-Audiothek-RSS/
 COPY ./ardaudiothek-rss.php /var/www/html/index.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM php:8.3-apache
+LABEL org.opencontainers.image.source="https://github.com/frauhottelmann/ARD-Audiothek-RSS"
 COPY ./ardaudiothek-rss.php /var/www/html/index.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM php:8.2-apache
+FROM php:8.3-apache
 COPY ./ardaudiothek-rss.php /var/www/html/index.php

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # ARD Audiothek rss feed generator
 
-## Dependencies
- - php-curl
-
 ## Usage
 
 Simply pass the id of the show with the show parameter
@@ -11,8 +8,8 @@ Show url: https://www.ardaudiothek.de/sendung/kalk-und-welk/10777871/
 
 Id: 10777871
 
-Feed url: https://example.com/ardaudiothek-rss.php?show=10777871
+Feed url: http://localhost:8080/index.php?show=10777871
 
 If you only want to receive the n newest episodes, pass the latest parameter too:
 
-Feed url with 10 newest episodes: https://example.com/ardaudiothek-rss.php?show=10777871&latest=10
+Feed url with 10 newest episodes: http://localhost:8080/index.php?show=10777871&latest=10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-version: '3.3'
-
+version: "3"
 services:
   application:
-    image: ghcr.io/frauhottelmann/ard-audiothek-rss:latest
+    container_name: ARD-Audiothek-RSS
+    image: ghcr.io/matztam/ard-audiothek-rss:latest
     ports:
       - 8080:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: '3.3'
 
 services:
   application:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/frauhottelmann/ard-audiothek-rss:latest
     ports:
       - 8080:80


### PR DESCRIPTION
Here is the pull request. I have done the following:
- update to php 8.3 base image (unrelated ;) )
- added a label to the Dockerfile to point to the repo
- updated the docker-compose to point to the new image instead of building the image and added a container_name
- updated the README to a more general URL and changed to index.php, since that is what the file is copied to in the docker-container. Maybe we should add a section for use with the docker container and one for general usage...

To get the autobuild to work you need to generate a personal access token (https://github.com/settings/tokens). I created a classic token with the scopes repo (all) and write:package and read:packages. Then add a repository secret in the repo named TOKEN with the access token (should be here: https://github.com/matztam/ARD-Audiothek-RS/settings/secrets/actions).

The github action will build on each change in the master branch and publish to ghcr.io/matztam/ard-audiothek-rss. I think you need to connect the package to the repo once. You can have a look at my main branch. It is setup completely.
