### PR TITLE
Feature: Podcast-Suche im Web-Frontend

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,5 +66,71 @@
 
 <!-- noch einen Button einbauen, der den Link unten drunter anzeigt und potentiell in die Zwischenablage kopiert? -->
 
+<!-- Podcast-Suche -->
+<h2>Podcast suchen</h2>
+<p>Hier kannst du nach einem Podcast suchen. Klicke auf einen Vorschlag, um die ID zu übernehmen.</p>
+<input type="text" id="searchQuery" placeholder="Suchbegriff..." />
+<input type="button" id="searchBtn" value="Suchen" />
+<ul id="searchResults" style="list-style-type:none; padding-left:0;"></ul>
+<script>
+async function searchPodcasts() {
+    const query = document.getElementById('searchQuery').value.trim();
+    const resultsList = document.getElementById('searchResults');
+    resultsList.innerHTML = '';
+    if (!query) return;
+    resultsList.innerHTML = '<li>Suche läuft...</li>';
+    try {
+        const response = await fetch(`https://api.ardaudiothek.de/search?query=${encodeURIComponent(query)}`);
+        const data = await response.json();
+        const nodes = (data.data && data.data.search && data.data.search.programSets && data.data.search.programSets.nodes) || [];
+        if (nodes.length === 0) {
+            resultsList.innerHTML = '<li>Keine Podcasts gefunden.</li>';
+            return;
+        }
+        resultsList.innerHTML = '';
+        nodes.forEach(podcast => {
+            const li = document.createElement('li');
+            li.style.cursor = 'pointer';
+            li.style.marginBottom = '12px';
+            li.style.display = 'flex';
+            li.style.alignItems = 'center';
+            li.style.padding = '6px 0';
+            li.style.borderBottom = '1px solid #eee';
+            
+            // Thumbnail
+            if (podcast.image && podcast.image.url1X1) {
+                const img = document.createElement('img');
+                img.src = podcast.image.url1X1.replace('{width}', '48');
+                img.alt = podcast.title;
+                img.style.width = '48px';
+                img.style.height = '48px';
+                img.style.objectFit = 'cover';
+                img.style.borderRadius = '8px';
+                img.style.marginRight = '12px';
+                li.appendChild(img);
+            }
+            // Text
+            const textDiv = document.createElement('div');
+            textDiv.innerHTML = `<strong>${podcast.title}</strong><br><span style='font-size:13px;color:#888;'>ID: ${podcast.id}</span>`;
+            if (podcast.synopsis) {
+                textDiv.title = podcast.synopsis;
+            }
+            li.appendChild(textDiv);
+            li.onclick = () => {
+                document.getElementById('FeedID').value = podcast.id;
+                resultsList.innerHTML = '';
+            };
+            resultsList.appendChild(li);
+        });
+    } catch (e) {
+        resultsList.innerHTML = '<li>Fehler bei der Suche.</li>';
+    }
+}
+document.getElementById('searchBtn').onclick = searchPodcasts;
+document.getElementById('searchQuery').addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') searchPodcasts();
+});
+</script>
+
   </body>
 </html>


### PR DESCRIPTION
Hallo,
ich habe eine Suchfunktion mit Vorschaubildern für Podcasts im Web-Frontend ergänzt. Damit können Nutzer nach Podcasts suchen und die ID direkt übernehmen.
Das könnte ein Lösung für [Issue 19](https://github.com/matztam/ARD-Audiothek-RSS/issues/19) sein.
Viele Grüße
Zeik